### PR TITLE
Fix code block copy button layout instability

### DIFF
--- a/components/CodeCopyButtons.tsx
+++ b/components/CodeCopyButtons.tsx
@@ -10,6 +10,7 @@ type Target = {
   element: HTMLElement
   pre: HTMLElement
   wrapper: HTMLElement
+  language: string
 }
 
 export function CodeCopyButtons() {
@@ -29,7 +30,6 @@ export function CodeCopyButtons() {
     const mapped: Target[] = []
 
     for (const [index, preElement] of preElements.entries()) {
-      if (preElement.offsetParent === null) continue
       const parent = preElement.parentElement
       if (!parent) continue
 
@@ -42,10 +42,14 @@ export function CodeCopyButtons() {
 
       const host = document.createElement("div")
       host.dataset.codeCopyHost = "true"
-      host.className = "pointer-events-none sticky top-16 z-10 mb-[-2.5rem] flex h-10 justify-end pr-2 pt-2 lg:top-2"
+      host.className = "code-copy-header"
       wrapper.prepend(host)
 
-      mapped.push({ id: `code-copy-${index}`, element: host, pre: preElement, wrapper })
+      const code = preElement.querySelector("code")
+      const languageClass = code?.className.match(/language-([\w-]+)/)?.[1]
+      const language = preElement.dataset.language || code?.dataset.language || languageClass || "text"
+
+      mapped.push({ id: `code-copy-${index}`, element: host, pre: preElement, wrapper, language })
     }
 
     setTargets(mapped)
@@ -72,15 +76,17 @@ export function CodeCopyButtons() {
     <>
       {targets.map((target) =>
         createPortal(
-          <button
-            key={target.id}
-            type="button"
-            onClick={() => void handleCopy(target)}
-            className="pointer-events-auto rounded-md bg-black/80 p-1.5 text-white backdrop-blur hover:bg-black"
-            aria-label="Copy code"
-          >
-            {copiedId === target.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-          </button>,
+          <div key={target.id} className="flex h-10 items-center justify-between border-b border-border bg-muted px-3 text-sm text-foreground">
+            <span className="font-mono text-xs uppercase tracking-wide">{target.language}</span>
+            <button
+              type="button"
+              onClick={() => void handleCopy(target)}
+              className="pointer-events-auto inline-flex h-7 w-7 items-center justify-center border border-border bg-background text-foreground"
+              aria-label="Copy code"
+            >
+              {copiedId === target.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </button>
+          </div>,
           target.element,
         ),
       )}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -215,6 +215,17 @@
     width: 100%;
     max-width: 100%;
     min-width: 0;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--background));
+  }
+
+  .prose [data-code-copy-wrapper='true'] [data-code-copy-host='true'] {
+    position: relative;
+    z-index: 1;
+  }
+
+  .prose [data-code-copy-wrapper='true'] .code-copy-header {
+    width: 100%;
   }
 
   .prose pre {
@@ -223,6 +234,11 @@
     min-width: 0;
     overflow-x: auto;
     box-sizing: border-box;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: hsl(var(--background)) !important;
   }
 
   .prose pre.shiki {


### PR DESCRIPTION
### Motivation
- The inline sticky copy button layout caused the copy button to overflow code block bounds and behave inconsistently inside accordions, so the copy UI needs to be constrained inside the code block and avoid sticky overlays.
- Language labels and copy controls should be reliably available without relying on element visibility heuristics.

### Description
- Replace the sticky overlay with an in-flow header inside the code block wrapper and render a language label plus a copy button (`components/CodeCopyButtons.tsx`).
- Extract language from `pre[data-language]`, `code[data-language]`, or `language-*` class and fall back to `text` when missing.
- Update wrapper and `pre` styles to add a border and background to the wrapper, remove rounded corners on `pre`, and ensure the header uses only theme `foreground`/`background` and `muted` colors (`styles/globals.css`).
- Keep changes minimal and non-intrusive: no emojis, use `lucide` icons already present, and avoid additional visual decorations.

### Testing
- `pnpm build` completed successfully.
- `pnpm lint` could not be run non-interactively because `next lint` triggers an initial ESLint configuration prompt in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6f81b23c832f8d4f18e7aabadd27)