### PR TITLE
Show language label and restyle code copy header for code blocks

### DIFF
--- a/components/CodeCopyButtons.tsx
+++ b/components/CodeCopyButtons.tsx
@@ -10,6 +10,29 @@ type Target = {
   element: HTMLElement
   pre: HTMLElement
   wrapper: HTMLElement
+  language: string
+}
+
+function normalizeLanguage(value: string) {
+  return value.replace(/[_-]+/g, " ").trim()
+}
+
+function resolveLanguage(preElement: HTMLElement) {
+  const code = preElement.querySelector("code")
+  const candidates = [
+    preElement.dataset.language,
+    preElement.dataset.lang,
+    code?.getAttribute("data-language") || undefined,
+    code?.getAttribute("data-lang") || undefined,
+    preElement.className.match(/language-([\w-]+)/)?.[1],
+    code?.className.match(/language-([\w-]+)/)?.[1],
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim()) return normalizeLanguage(candidate)
+  }
+
+  return "text"
 }
 
 export function CodeCopyButtons() {
@@ -29,7 +52,6 @@ export function CodeCopyButtons() {
     const mapped: Target[] = []
 
     for (const [index, preElement] of preElements.entries()) {
-      if (preElement.offsetParent === null) continue
       const parent = preElement.parentElement
       if (!parent) continue
 
@@ -42,10 +64,12 @@ export function CodeCopyButtons() {
 
       const host = document.createElement("div")
       host.dataset.codeCopyHost = "true"
-      host.className = "pointer-events-none sticky top-16 z-10 mb-[-2.5rem] flex h-10 justify-end pr-2 pt-2 lg:top-2"
+      host.className = "code-copy-header"
       wrapper.prepend(host)
 
-      mapped.push({ id: `code-copy-${index}`, element: host, pre: preElement, wrapper })
+      const language = resolveLanguage(preElement)
+
+      mapped.push({ id: `code-copy-${index}`, element: host, pre: preElement, wrapper, language })
     }
 
     setTargets(mapped)
@@ -72,15 +96,17 @@ export function CodeCopyButtons() {
     <>
       {targets.map((target) =>
         createPortal(
-          <button
-            key={target.id}
-            type="button"
-            onClick={() => void handleCopy(target)}
-            className="pointer-events-auto rounded-md bg-black/80 p-1.5 text-white backdrop-blur hover:bg-black"
-            aria-label="Copy code"
-          >
-            {copiedId === target.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-          </button>,
+          <div key={target.id} className="flex h-10 items-center justify-between border-b border-[#2a3140] bg-[#0b0f17] px-3 text-sm text-[#e5e7eb]">
+            <span className="font-mono text-xs uppercase tracking-wide">{target.language}</span>
+            <button
+              type="button"
+              onClick={() => void handleCopy(target)}
+              className="pointer-events-auto inline-flex h-7 w-7 items-center justify-center bg-transparent text-[#e5e7eb]"
+              aria-label="Copy code"
+            >
+              {copiedId === target.id ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </button>
+          </div>,
           target.element,
         ),
       )}

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -195,7 +195,8 @@ export async function getDocBySlug(slug: string, isHome = false) {
         .use(remarkWrapHeadings)
         .use(remarkRehype, { allowDangerousHtml: true })
         .use(rehypeShiki, {
-          theme: 'aurora-x'
+          theme: 'aurora-x',
+          addLanguageClass: true
         })
         .use(rehypeKatex)
         .use(rehypeStringify, { allowDangerousHtml: true })

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -205,7 +205,7 @@
     padding: 0 0 0.875rem;
   }
 
-  .prose details > *:not(summary):first-of-type {
+  .prose details > *:not(summary):first-of-type:not([data-code-copy-wrapper='true']) {
     margin-top: 0.75rem;
     padding-top: 0.75rem;
   }
@@ -215,6 +215,20 @@
     width: 100%;
     max-width: 100%;
     min-width: 0;
+    margin-top: 0 !important;
+    padding-top: 0 !important;
+    border: 1px solid #2a3140;
+    background: #0b0f17;
+    color: #e5e7eb;
+  }
+
+  .prose [data-code-copy-wrapper='true'] [data-code-copy-host='true'] {
+    position: relative;
+    z-index: 1;
+  }
+
+  .prose [data-code-copy-wrapper='true'] .code-copy-header {
+    width: 100%;
   }
 
   .prose pre {
@@ -223,6 +237,12 @@
     min-width: 0;
     overflow-x: auto;
     box-sizing: border-box;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: #0b0f17 !important;
+    color: #e5e7eb !important;
   }
 
   .prose pre.shiki {


### PR DESCRIPTION
### Motivation
- Surface the detected language for each code block and provide a more informative header for copy actions.  
- Normalize language identifiers coming from various attributes and class names so labels are consistent.  
- Improve visuals and layout of inlined code copy UI to match site styling and ensure code blocks render cleanly.

### Description
- Added `normalizeLanguage` and `resolveLanguage` helpers and include a `language` property on each `Target` in `components/CodeCopyButtons.tsx`.  
- Replaced the single floating copy button with a styled header showing the language and a copy button, and removed the old host classes in favor of a `.code-copy-header` wrapper.  
- Enabled `addLanguageClass: true` for `rehypeShiki` in `lib/docs.ts` so language information is preserved on rendered code blocks.  
- Updated `styles/globals.css` to exempt code-copy wrappers from certain spacing rules and to add styling for the code-copy wrapper, header, and pre/code backgrounds to match the new header design.

### Testing
- Ran TypeScript typecheck (`tsc --noEmit`) and a local Next.js build (`next build`) to validate compilation and bundling, and both completed successfully.  
- No automated unit tests were modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6f81b23c832f8d4f18e7aabadd27)