### PR TITLE
API /api/summarize をサイト内記事の要約専用に変更

### DIFF
--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { getDocBySlug } from "@/lib/docs"
-import { MAX_SUMMARY_TEXT_LENGTH } from "@/lib/summary"
 
 /**
  * Vercel の無料枠（Hobby）は Serverless Function の実行時間が最大 10 秒です。
@@ -59,7 +58,6 @@ async function generateSummary(text: string): Promise<string> {
 }
 
 class ArticleNotFoundError extends Error {}
-class ArticleTooLongError extends Error {}
 class MissingApiKeyError extends Error {}
 
 const getCachedSummary = unstable_cache(
@@ -68,10 +66,6 @@ const getCachedSummary = unstable_cache(
 
     if (!doc) {
       throw new ArticleNotFoundError("指定された記事が見つかりません")
-    }
-
-    if (doc.markdown.length > MAX_SUMMARY_TEXT_LENGTH) {
-      throw new ArticleTooLongError("記事本文が要約可能な長さを超えています")
     }
 
     if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
@@ -115,10 +109,6 @@ export async function POST(request: Request): Promise<NextResponse<SummarizeResp
   } catch (error) {
     if (error instanceof ArticleNotFoundError) {
       return NextResponse.json({ error: error.message }, { status: 404 })
-    }
-
-    if (error instanceof ArticleTooLongError) {
-      return NextResponse.json({ error: error.message }, { status: 413 })
     }
 
     if (error instanceof MissingApiKeyError) {

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -36,7 +36,7 @@ async function generateSummary(text: string): Promise<string> {
     // GOOGLE_GENERATIVE_AI_API_KEY を自動的に参照する。
     // gemini-2.5-flash は新規ユーザー向けに提供終了したため、
     // 高速・低コストで無料枠に適した現行の安定モデルを使用する。
-    model: google("gemini-3.1-flash-lite-preview"),
+    model: google("gemini-3.1-flash-lite"),
     prompt: `以下の文章を5行以内で簡潔に要約してください：\n\n${text}`,
     // 出力トークンの上限（5行の要約には十分）。暴走を防ぎ、10秒枠に収める。
     maxOutputTokens: 512,
@@ -58,27 +58,34 @@ async function generateSummary(text: string): Promise<string> {
   return trimmed
 }
 
-/**
- * articleId をキャッシュキーとして AI 要約結果をサーバー側（Data Cache）に保存する。
- *
- * - 本文はサーバー側で articleId から取得し、クライアントからは受け取らない。
- * - `tags: ['summary']` を付与し、記事更新時に
- *   `revalidateTag('summary')` でオンデマンド再検証（強制クリア）できるようにする。
- */
-function getCachedSummary(articleId: string, markdown: string): Promise<string> {
-  const cachedFn = unstable_cache(
-    async () => generateSummary(markdown),
-    // キャッシュキーの一部。articleId ごとに独立したキャッシュになる。
-    ["article-summary", articleId],
-    {
-      tags: ["summary"],
-      // 明示的に revalidateTag するまで保持（時間による自動失効なし）
-      revalidate: false,
-    },
-  )
+class ArticleNotFoundError extends Error {}
+class ArticleTooLongError extends Error {}
+class MissingApiKeyError extends Error {}
 
-  return cachedFn()
-}
+const getCachedSummary = unstable_cache(
+  async (articleId: string): Promise<string> => {
+    const doc = await getDocBySlug(articleId === "home" ? "" : articleId, articleId === "home")
+
+    if (!doc) {
+      throw new ArticleNotFoundError("指定された記事が見つかりません")
+    }
+
+    if (doc.markdown.length > MAX_SUMMARY_TEXT_LENGTH) {
+      throw new ArticleTooLongError("記事本文が要約可能な長さを超えています")
+    }
+
+    if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+      throw new MissingApiKeyError("サーバー設定エラー: GOOGLE_GENERATIVE_AI_API_KEY が未設定です")
+    }
+
+    return generateSummary(doc.markdown)
+  },
+  ["article-summary"],
+  {
+    tags: ["summary"],
+    revalidate: false,
+  },
+)
 
 // ---- POST ハンドラ --------------------------------------------------------
 
@@ -101,31 +108,23 @@ export async function POST(request: Request): Promise<NextResponse<SummarizeResp
   }
 
   const { articleId } = parsed.data
-  const doc = await getDocBySlug(articleId === "home" ? "" : articleId, articleId === "home")
-
-  if (!doc) {
-    return NextResponse.json({ error: "指定された記事が見つかりません" }, { status: 404 })
-  }
-
-  if (doc.markdown.length > MAX_SUMMARY_TEXT_LENGTH) {
-    return NextResponse.json(
-      { error: "記事本文が要約可能な長さを超えています" },
-      { status: 413 },
-    )
-  }
-
-  // API キー未設定を早期に検知
-  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-    return NextResponse.json(
-      { error: "サーバー設定エラー: GOOGLE_GENERATIVE_AI_API_KEY が未設定です" },
-      { status: 500 },
-    )
-  }
 
   try {
-    const summary = await getCachedSummary(articleId, doc.markdown)
+    const summary = await getCachedSummary(articleId)
     return NextResponse.json({ summary, cached: true })
   } catch (error) {
+    if (error instanceof ArticleNotFoundError) {
+      return NextResponse.json({ error: error.message }, { status: 404 })
+    }
+
+    if (error instanceof ArticleTooLongError) {
+      return NextResponse.json({ error: error.message }, { status: 413 })
+    }
+
+    if (error instanceof MissingApiKeyError) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
     const detail = error instanceof Error ? error.message : String(error)
     console.log("[v0] summarize error:", detail)
     return NextResponse.json(

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -3,7 +3,7 @@ import { generateText } from "ai"
 import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { z } from "zod"
-import { getDocBySlug } from "@/lib/docs"
+import { getDocMarkdownBySlug } from "@/lib/docs"
 
 /**
  * Vercel の無料枠（Hobby）は Serverless Function の実行時間が最大 10 秒です。
@@ -37,6 +37,8 @@ async function generateSummary(text: string): Promise<string> {
     // 高速・低コストで無料枠に適した現行の安定モデルを使用する。
     model: google("gemini-3.1-flash-lite"),
     prompt: `以下の文章を5行以内で簡潔に要約してください：\n\n${text}`,
+    maxRetries: 0,
+    abortSignal: AbortSignal.timeout(8000),
     // 出力トークンの上限（5行の要約には十分）。暴走を防ぎ、10秒枠に収める。
     maxOutputTokens: 512,
     providerOptions: {
@@ -62,9 +64,9 @@ class MissingApiKeyError extends Error {}
 
 const getCachedSummary = unstable_cache(
   async (articleId: string): Promise<string> => {
-    const doc = await getDocBySlug(articleId === "home" ? "" : articleId, articleId === "home")
+    const markdown = getDocMarkdownBySlug(articleId === "home" ? "" : articleId, articleId === "home")
 
-    if (!doc) {
+    if (!markdown) {
       throw new ArticleNotFoundError("指定された記事が見つかりません")
     }
 
@@ -72,7 +74,7 @@ const getCachedSummary = unstable_cache(
       throw new MissingApiKeyError("サーバー設定エラー: GOOGLE_GENERATIVE_AI_API_KEY が未設定です")
     }
 
-    return generateSummary(doc.markdown)
+    return generateSummary(markdown)
   },
   ["article-summary"],
   {

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -4,6 +4,7 @@ import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { z } from "zod"
 import { getDocBySlug } from "@/lib/docs"
+import { MAX_SUMMARY_TEXT_LENGTH } from "@/lib/summary"
 
 /**
  * Vercel の無料枠（Hobby）は Serverless Function の実行時間が最大 10 秒です。
@@ -104,6 +105,13 @@ export async function POST(request: Request): Promise<NextResponse<SummarizeResp
 
   if (!doc) {
     return NextResponse.json({ error: "指定された記事が見つかりません" }, { status: 404 })
+  }
+
+  if (doc.markdown.length > MAX_SUMMARY_TEXT_LENGTH) {
+    return NextResponse.json(
+      { error: "記事本文が要約可能な長さを超えています" },
+      { status: 413 },
+    )
   }
 
   // API キー未設定を早期に検知

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -36,7 +36,7 @@ async function generateSummary(text: string): Promise<string> {
     // GOOGLE_GENERATIVE_AI_API_KEY を自動的に参照する。
     // gemini-2.5-flash は新規ユーザー向けに提供終了したため、
     // 高速・低コストで無料枠に適した現行の安定モデルを使用する。
-    model: google("gemini-3.1-flash-lite"),
+    model: google("gemini-3.1-flash-lite-preview"),
     prompt: `以下の文章を5行以内で簡潔に要約してください：\n\n${text}`,
     // 出力トークンの上限（5行の要約には十分）。暴走を防ぎ、10秒枠に収める。
     maxOutputTokens: 512,

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -3,7 +3,7 @@ import { generateText } from "ai"
 import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { z } from "zod"
-import { getDocMarkdownBySlug } from "@/lib/docs"
+import { getDocMarkdownBySlug } from "@/lib/doc-markdown"
 
 /**
  * Vercel の無料枠（Hobby）は Serverless Function の実行時間が最大 10 秒です。

--- a/app/api/summarize/route.ts
+++ b/app/api/summarize/route.ts
@@ -3,6 +3,7 @@ import { generateText } from "ai"
 import { unstable_cache } from "next/cache"
 import { NextResponse } from "next/server"
 import { z } from "zod"
+import { getDocBySlug } from "@/lib/docs"
 
 /**
  * Vercel の無料枠（Hobby）は Serverless Function の実行時間が最大 10 秒です。
@@ -17,8 +18,7 @@ export const runtime = "nodejs"
 
 const RequestSchema = z.object({
   articleId: z.string().min(1, "articleId は必須です"),
-  text: z.string().min(1, "text は必須です"),
-})
+}).strict()
 
 type SummarizeResponse =
   | { summary: string; cached: boolean }
@@ -60,14 +60,13 @@ async function generateSummary(text: string): Promise<string> {
 /**
  * articleId をキャッシュキーとして AI 要約結果をサーバー側（Data Cache）に保存する。
  *
- * - `text` はクロージャで渡すことで **キャッシュキーには含めず**、articleId だけで識別する。
- *   → 同じ記事に対しては本文が多少変わっても API を叩かず、キャッシュを返す。
+ * - 本文はサーバー側で articleId から取得し、クライアントからは受け取らない。
  * - `tags: ['summary']` を付与し、記事更新時に
  *   `revalidateTag('summary')` でオンデマンド再検証（強制クリア）できるようにする。
  */
-function getCachedSummary(articleId: string, text: string): Promise<string> {
+function getCachedSummary(articleId: string, markdown: string): Promise<string> {
   const cachedFn = unstable_cache(
-    async () => generateSummary(text),
+    async () => generateSummary(markdown),
     // キャッシュキーの一部。articleId ごとに独立したキャッシュになる。
     ["article-summary", articleId],
     {
@@ -83,14 +82,6 @@ function getCachedSummary(articleId: string, text: string): Promise<string> {
 // ---- POST ハンドラ --------------------------------------------------------
 
 export async function POST(request: Request): Promise<NextResponse<SummarizeResponse>> {
-  // API キー未設定を早期に検知
-  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-    return NextResponse.json(
-      { error: "サーバー設定エラー: GOOGLE_GENERATIVE_AI_API_KEY が未設定です" },
-      { status: 500 },
-    )
-  }
-
   // JSON パース
   let body: unknown
   try {
@@ -108,10 +99,23 @@ export async function POST(request: Request): Promise<NextResponse<SummarizeResp
     )
   }
 
-  const { articleId, text } = parsed.data
+  const { articleId } = parsed.data
+  const doc = await getDocBySlug(articleId === "home" ? "" : articleId, articleId === "home")
+
+  if (!doc) {
+    return NextResponse.json({ error: "指定された記事が見つかりません" }, { status: 404 })
+  }
+
+  // API キー未設定を早期に検知
+  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    return NextResponse.json(
+      { error: "サーバー設定エラー: GOOGLE_GENERATIVE_AI_API_KEY が未設定です" },
+      { status: 500 },
+    )
+  }
 
   try {
-    const summary = await getCachedSummary(articleId, text)
+    const summary = await getCachedSummary(articleId, doc.markdown)
     return NextResponse.json({ summary, cached: true })
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error)

--- a/app/docs-layout.tsx
+++ b/app/docs-layout.tsx
@@ -26,7 +26,7 @@ import { useIsTocItemActive } from "../hooks/useIsTocItemActive"
 import { useTocIndicatorStyle } from "../hooks/useTocIndicatorStyle"
 import { SITE_TITLE } from "@/lib/siteSetting"
 import { cn } from "@/lib/utils"
-import { isSummaryTextWithinLimit, shouldExecuteSummary } from "@/lib/summary"
+import { shouldExecuteSummary } from "@/lib/summary"
 
 interface DocTreeNode {
   name: string
@@ -184,7 +184,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
               </div>
               <LastUpdated lastUpdated={lastUpdated} />
             </div>
-            {summaryText && shouldExecuteSummary(summaryText) && isSummaryTextWithinLimit(summaryText) && articleId && <AiSummary articleId={articleId} />}
+            {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} />}
             <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
             <CodeCopyButtons />
             <PrevNextNav prevNext={prevNext} />
@@ -215,7 +215,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
         <div className="container py-6">
           <DocsBreadcrumbs breadcrumbs={breadcrumbs} />
           <LastUpdated lastUpdated={lastUpdated} />
-          {summaryText && shouldExecuteSummary(summaryText) && isSummaryTextWithinLimit(summaryText) && articleId && <AiSummary articleId={articleId} className="mt-4" />}
+          {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} className="mt-4" />}
           <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
           <CodeCopyButtons />
           <PrevNextNav prevNext={prevNext} />

--- a/app/docs-layout.tsx
+++ b/app/docs-layout.tsx
@@ -26,7 +26,7 @@ import { useIsTocItemActive } from "../hooks/useIsTocItemActive"
 import { useTocIndicatorStyle } from "../hooks/useTocIndicatorStyle"
 import { SITE_TITLE } from "@/lib/siteSetting"
 import { cn } from "@/lib/utils"
-import { shouldExecuteSummary } from "@/lib/summary"
+import { isSummaryTextWithinLimit, shouldExecuteSummary } from "@/lib/summary"
 
 interface DocTreeNode {
   name: string
@@ -184,7 +184,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
               </div>
               <LastUpdated lastUpdated={lastUpdated} />
             </div>
-            {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} />}
+            {summaryText && shouldExecuteSummary(summaryText) && isSummaryTextWithinLimit(summaryText) && articleId && <AiSummary articleId={articleId} />}
             <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
             <CodeCopyButtons />
             <PrevNextNav prevNext={prevNext} />
@@ -215,7 +215,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
         <div className="container py-6">
           <DocsBreadcrumbs breadcrumbs={breadcrumbs} />
           <LastUpdated lastUpdated={lastUpdated} />
-          {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} className="mt-4" />}
+          {summaryText && shouldExecuteSummary(summaryText) && isSummaryTextWithinLimit(summaryText) && articleId && <AiSummary articleId={articleId} className="mt-4" />}
           <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
           <CodeCopyButtons />
           <PrevNextNav prevNext={prevNext} />

--- a/app/docs-layout.tsx
+++ b/app/docs-layout.tsx
@@ -26,13 +26,7 @@ import { useIsTocItemActive } from "../hooks/useIsTocItemActive"
 import { useTocIndicatorStyle } from "../hooks/useTocIndicatorStyle"
 import { SITE_TITLE } from "@/lib/siteSetting"
 import { cn } from "@/lib/utils"
-
-function shouldExecuteSummary(summaryText: string): boolean {
-  if (!summaryText) return false;
-  const headingCount = (summaryText.match(/^#{2,3}\s/gm) || []).length;
-  const textLength = summaryText.length;
-  return textLength >= 1000 || headingCount >= 6;
-}
+import { shouldExecuteSummary } from "@/lib/summary"
 
 interface DocTreeNode {
   name: string

--- a/app/docs-layout.tsx
+++ b/app/docs-layout.tsx
@@ -190,7 +190,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
               </div>
               <LastUpdated lastUpdated={lastUpdated} />
             </div>
-            {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} text={summaryText} />}
+            {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} />}
             <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
             <CodeCopyButtons />
             <PrevNextNav prevNext={prevNext} />
@@ -221,7 +221,7 @@ export function DocsLayout({ children, docTree, toc, title, lastUpdated, breadcr
         <div className="container py-6">
           <DocsBreadcrumbs breadcrumbs={breadcrumbs} />
           <LastUpdated lastUpdated={lastUpdated} />
-          {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} text={summaryText} className="mt-4" />}
+          {summaryText && shouldExecuteSummary(summaryText) && articleId && <AiSummary articleId={articleId} className="mt-4" />}
           <div className="prose prose-slate dark:prose-invert max-w-none">{children}</div>
           <CodeCopyButtons />
           <PrevNextNav prevNext={prevNext} />

--- a/components/AiSummary.tsx
+++ b/components/AiSummary.tsx
@@ -7,14 +7,12 @@ import { cn } from "@/lib/utils"
 interface AiSummaryProps {
   /** キャッシュ識別子（記事のスラッグ） */
   articleId: string
-  /** 要約対象の本文（Markdown） */
-  text: string
   className?: string
 }
 
 type Status = "idle" | "loading" | "done" | "error"
 
-export function AiSummary({ articleId, text, className }: AiSummaryProps) {
+export function AiSummary({ articleId, className }: AiSummaryProps) {
   const [status, setStatus] = useState<Status>("idle")
   const [summary, setSummary] = useState("")
   const [error, setError] = useState("")
@@ -27,7 +25,7 @@ export function AiSummary({ articleId, text, className }: AiSummaryProps) {
       const res = await fetch("/api/summarize", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ articleId, text }),
+        body: JSON.stringify({ articleId }),
       })
 
       const data = (await res.json()) as { summary?: string; error?: string }

--- a/lib/doc-markdown.ts
+++ b/lib/doc-markdown.ts
@@ -1,0 +1,66 @@
+import fs from "fs"
+import path from "path"
+import matter from "gray-matter"
+import { yamlToMarkdown } from "./yaml-docs"
+import { isApiDocument, renderApiDocToMarkdown } from "@/lib/api-docs/render-api-doc"
+
+const DOCS_DIRECTORY = path.join(process.cwd(), "content")
+
+export function resolveDocPath(slug: string, isHome = false): string | null {
+  let filePath = slug
+
+  if (filePath === "" && !isHome) {
+    filePath = "index"
+  }
+
+  const filePathParts = filePath.split("/").map((part) => part.replace(/-/g, " "))
+  const filePathWithSpaces = filePathParts.join("/")
+  const possiblePaths = [
+    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.md`),
+    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.md"),
+    path.join(DOCS_DIRECTORY, `${filePath}.md`),
+    path.join(DOCS_DIRECTORY, filePath, "index.md"),
+
+    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.yaml`),
+    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.yaml"),
+    path.join(DOCS_DIRECTORY, `${filePath}.yaml`),
+    path.join(DOCS_DIRECTORY, filePath, "index.yaml"),
+
+    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.yml`),
+    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.yml"),
+    path.join(DOCS_DIRECTORY, `${filePath}.yml`),
+    path.join(DOCS_DIRECTORY, filePath, "index.yml"),
+  ]
+
+  return possiblePaths.find((p) => fs.existsSync(p)) ?? null
+}
+
+export function readDocFileAsMarkdown(fullPath: string): string | null {
+  const isYAML = fullPath.endsWith(".yaml") || fullPath.endsWith(".yml")
+  const rawFile = fs.readFileSync(fullPath, "utf8")
+  const fileContents = isYAML
+    ? (isApiDocument(rawFile)
+      ? renderApiDocToMarkdown(rawFile)
+      : yamlToMarkdown(rawFile))
+    : rawFile
+
+  return fileContents || null
+}
+
+export function getDocMarkdownBySlug(slug: string, isHome = false): string | null {
+  const fullPath = resolveDocPath(slug, isHome)
+
+  if (!fullPath) {
+    console.warn(`No file found for ${slug}`)
+    return null
+  }
+
+  try {
+    const fileContents = readDocFileAsMarkdown(fullPath)
+    if (!fileContents) return null
+    return matter(fileContents).content
+  } catch (error) {
+    console.error(`Error reading markdown for ${slug}:`, error)
+    return null
+  }
+}

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -21,6 +21,7 @@ import { GITHUB_REPO_BRANCH, GITHUB_REPO_NAME, GITHUB_REPO_USERNAME, IS_GITHUB_R
 import { yamlToMarkdown } from "./yaml-docs"
 import {isApiDocument, renderApiDocToMarkdown} from "@/lib/api-docs/render-api-doc";
 import remarkResolveContentImages from "./remarkResolveContentImages"
+import { readDocFileAsMarkdown, resolveDocPath } from "./doc-markdown"
 
 const DOCS_DIRECTORY = path.join(process.cwd(), "content")
 
@@ -128,65 +129,6 @@ function getAllFiles(dir: string): string[] {
   })
 
   return files
-}
-
-function resolveDocPath(slug: string, isHome = false): string | null {
-  let filePath = slug
-
-  if (filePath === "" && !isHome) {
-    filePath = "index"
-  }
-
-  const filePathParts = filePath.split("/").map((part) => part.replace(/-/g, " "))
-  const filePathWithSpaces = filePathParts.join("/")
-  const possiblePaths = [
-    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.md`),
-    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.md"),
-    path.join(DOCS_DIRECTORY, `${filePath}.md`),
-    path.join(DOCS_DIRECTORY, filePath, "index.md"),
-
-    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.yaml`),
-    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.yaml"),
-    path.join(DOCS_DIRECTORY, `${filePath}.yaml`),
-    path.join(DOCS_DIRECTORY, filePath, "index.yaml"),
-
-    path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.yml`),
-    path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.yml"),
-    path.join(DOCS_DIRECTORY, `${filePath}.yml`),
-    path.join(DOCS_DIRECTORY, filePath, "index.yml"),
-  ]
-
-  return possiblePaths.find((p) => fs.existsSync(p)) ?? null
-}
-
-function readDocFileAsMarkdown(fullPath: string): string | null {
-  const isYAML = fullPath.endsWith(".yaml") || fullPath.endsWith(".yml")
-  const rawFile = fs.readFileSync(fullPath, "utf8")
-  const fileContents = isYAML
-    ? (isApiDocument(rawFile)
-      ? renderApiDocToMarkdown(rawFile)
-      : yamlToMarkdown(rawFile))
-    : rawFile
-
-  return fileContents || null
-}
-
-export function getDocMarkdownBySlug(slug: string, isHome = false): string | null {
-  const fullPath = resolveDocPath(slug, isHome)
-
-  if (!fullPath) {
-    console.warn(`No file found for ${slug}`)
-    return null
-  }
-
-  try {
-    const fileContents = readDocFileAsMarkdown(fullPath)
-    if (!fileContents) return null
-    return matter(fileContents).content
-  } catch (error) {
-    console.error(`Error reading markdown for ${slug}:`, error)
-    return null
-  }
 }
 
 // Get doc content by slug (with YAML support)

--- a/lib/docs.ts
+++ b/lib/docs.ts
@@ -130,23 +130,15 @@ function getAllFiles(dir: string): string[] {
   return files
 }
 
-// Get doc content by slug (with YAML support)
-export async function getDocBySlug(slug: string, isHome = false) {
-  // Convert slug to file path
+function resolveDocPath(slug: string, isHome = false): string | null {
   let filePath = slug
 
-  // Handle root path
-  if (filePath === "") {
-    if (!isHome) {
-      filePath = "index"
-    }
+  if (filePath === "" && !isHome) {
+    filePath = "index"
   }
 
-  // Convert hyphens back to spaces for file lookup
   const filePathParts = filePath.split("/").map((part) => part.replace(/-/g, " "))
   const filePathWithSpaces = filePathParts.join("/")
-
-  // Check for both formats (with spaces and with hyphens) and both file types (md, yaml, yml)
   const possiblePaths = [
     path.join(DOCS_DIRECTORY, `${filePathWithSpaces}.md`),
     path.join(DOCS_DIRECTORY, filePathWithSpaces, "index.md"),
@@ -164,13 +156,23 @@ export async function getDocBySlug(slug: string, isHome = false) {
     path.join(DOCS_DIRECTORY, filePath, "index.yml"),
   ]
 
-  let fullPath = ""
-  for (const p of possiblePaths) {
-    if (fs.existsSync(p)) {
-      fullPath = p
-      break
-    }
-  }
+  return possiblePaths.find((p) => fs.existsSync(p)) ?? null
+}
+
+function readDocFileAsMarkdown(fullPath: string): string | null {
+  const isYAML = fullPath.endsWith(".yaml") || fullPath.endsWith(".yml")
+  const rawFile = fs.readFileSync(fullPath, "utf8")
+  const fileContents = isYAML
+    ? (isApiDocument(rawFile)
+      ? renderApiDocToMarkdown(rawFile)
+      : yamlToMarkdown(rawFile))
+    : rawFile
+
+  return fileContents || null
+}
+
+export function getDocMarkdownBySlug(slug: string, isHome = false): string | null {
+  const fullPath = resolveDocPath(slug, isHome)
 
   if (!fullPath) {
     console.warn(`No file found for ${slug}`)
@@ -178,13 +180,26 @@ export async function getDocBySlug(slug: string, isHome = false) {
   }
 
   try {
-    const isYAML = fullPath.endsWith(".yaml") || fullPath.endsWith(".yml")
-    const rawFile = fs.readFileSync(fullPath, "utf8")
-    const fileContents = isYAML
-      ? (isApiDocument(rawFile)
-        ? renderApiDocToMarkdown(rawFile)
-        : yamlToMarkdown(rawFile))
-      : rawFile
+    const fileContents = readDocFileAsMarkdown(fullPath)
+    if (!fileContents) return null
+    return matter(fileContents).content
+  } catch (error) {
+    console.error(`Error reading markdown for ${slug}:`, error)
+    return null
+  }
+}
+
+// Get doc content by slug (with YAML support)
+export async function getDocBySlug(slug: string, isHome = false) {
+  const fullPath = resolveDocPath(slug, isHome)
+
+  if (!fullPath) {
+    console.warn(`No file found for ${slug}`)
+    return null
+  }
+
+  try {
+    const fileContents = readDocFileAsMarkdown(fullPath)
     if (!fileContents) return null
     const { data, content } = matter(fileContents)
 

--- a/lib/summary.ts
+++ b/lib/summary.ts
@@ -1,11 +1,5 @@
-export const MAX_SUMMARY_TEXT_LENGTH = 120_000
-
 const MIN_SUMMARY_TEXT_LENGTH = 1000
 const MIN_SUMMARY_HEADING_COUNT = 6
-
-export function isSummaryTextWithinLimit(summaryText: string): boolean {
-  return summaryText.length <= MAX_SUMMARY_TEXT_LENGTH
-}
 
 export function shouldExecuteSummary(summaryText: string): boolean {
   if (!summaryText) return false

--- a/lib/summary.ts
+++ b/lib/summary.ts
@@ -1,0 +1,12 @@
+export const MAX_SUMMARY_TEXT_LENGTH = 120_000
+
+const MIN_SUMMARY_TEXT_LENGTH = 1000
+const MIN_SUMMARY_HEADING_COUNT = 6
+
+export function shouldExecuteSummary(summaryText: string): boolean {
+  if (!summaryText) return false
+  if (summaryText.length > MAX_SUMMARY_TEXT_LENGTH) return false
+
+  const headingCount = (summaryText.match(/^#{2,3}\s/gm) || []).length
+  return summaryText.length >= MIN_SUMMARY_TEXT_LENGTH || headingCount >= MIN_SUMMARY_HEADING_COUNT
+}

--- a/lib/summary.ts
+++ b/lib/summary.ts
@@ -3,9 +3,12 @@ export const MAX_SUMMARY_TEXT_LENGTH = 120_000
 const MIN_SUMMARY_TEXT_LENGTH = 1000
 const MIN_SUMMARY_HEADING_COUNT = 6
 
+export function isSummaryTextWithinLimit(summaryText: string): boolean {
+  return summaryText.length <= MAX_SUMMARY_TEXT_LENGTH
+}
+
 export function shouldExecuteSummary(summaryText: string): boolean {
   if (!summaryText) return false
-  if (summaryText.length > MAX_SUMMARY_TEXT_LENGTH) return false
 
   const headingCount = (summaryText.match(/^#{2,3}\s/gm) || []).length
   return summaryText.length >= MIN_SUMMARY_TEXT_LENGTH || headingCount >= MIN_SUMMARY_HEADING_COUNT


### PR DESCRIPTION
### Motivation
- 現行の `/api/summarize` はクライアント提出の任意テキストを Gemini に渡す汎用エンドポイントになっており第三者に悪用される余地があるため、責務を「サイト内の記事要約」のみに限定する。 

### Description
- リクエストスキーマを `articleId` のみ受け付ける strict な `RequestSchema` に変更し `text` を排除した。 (`app/api/summarize/route.ts`) 
- サーバー側で `getDocBySlug()` を使って `articleId` に対応する Markdown 本文を取得し、存在しない場合は `404` を返すようにした。 (`app/api/summarize/route.ts`) 
- 要約生成はサーバーが取得した本文 (`doc.markdown`) のみを `generateSummary()` に渡すようにし、クライアント送信の本文は一切使用しない設計にした。 (キャッシュ関数 `getCachedSummary` は記事ごとのキーを維持) (`app/api/summarize/route.ts`) 
- クライアント側コンポーネント `AiSummary` から `text` prop を削除し、API へは `articleId` のみ送信するように変更した。 (`components/AiSummary.tsx`) 
- `DocsLayout` 側の `AiSummary` 呼び出しを `articleId` のみ渡す形に修正した。 (`app/docs-layout.tsx`) 

### Testing
- 型チェックとして `pnpm exec tsc --noEmit` を実行し成功した。 
- `pnpm lint` は Next.js の対話型セットアッププロンプトが表示されるため非対話環境で完了できずブロックされた。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e109f412c832f8a0f5a05257ea385)